### PR TITLE
Update setsourceeditorvalue.md with correct api syntax

### DIFF
--- a/content/api/sceditor/setsourceeditorvalue.md
+++ b/content/api/sceditor/setsourceeditorvalue.md
@@ -13,7 +13,7 @@ Sets the current value of the source editor.
 
 {{% api_section title="Syntax" %}}
 ```js
-instance.getSourceEditorValue(val);
+instance.setSourceEditorValue(val);
 ```
 {{% /api_section %}}
 


### PR DESCRIPTION
Renamed instance.getSourceEditorValue to instance.setSourceEditorValue